### PR TITLE
Add AZ scoped quota check, make NatGatewayCountCheck AZ scoped

### DIFF
--- a/aws_quota/check/__init__.py
+++ b/aws_quota/check/__init__.py
@@ -28,7 +28,8 @@ def __all_subclasses(cls):
 
 
 ALL_CHECKS = sorted(
-    [clazz for clazz in __all_subclasses(QuotaCheck) if clazz not in [InstanceQuotaCheck, RegionQuotaCheck]],
+    [clazz for clazz in __all_subclasses(QuotaCheck) if clazz not in [InstanceQuotaCheck, RegionQuotaCheck, AvailabilityZoneQuotaCheck]],
     key=lambda clz: clz.key,
 )
 ALL_INSTANCE_SCOPED_CHECKS = list(filter(lambda check: check.scope == QuotaScope.INSTANCE, ALL_CHECKS))
+ALL_AZ_SCOPED_CHECKS = list(filter(lambda check: check.scope == QuotaScope.AZ, ALL_CHECKS))

--- a/aws_quota/check/quota_check.py
+++ b/aws_quota/check/quota_check.py
@@ -9,6 +9,7 @@ class QuotaScope(enum.Enum):
     ACCOUNT = 0
     REGION = 1
     INSTANCE = 2
+    AZ = 3
 
 
 class QuotaCheck:
@@ -40,11 +41,14 @@ class QuotaCheck:
             'account': get_account_id(self.boto_session)
         }
 
-        if self.scope in (QuotaScope.REGION, QuotaScope.INSTANCE):
+        if self.scope in (QuotaScope.REGION, QuotaScope.INSTANCE, QuotaScope.AZ):
             label_values['region'] = self.boto_session.region_name
 
         if self.scope == QuotaScope.INSTANCE:
             label_values['instance'] = self.instance_id
+
+        if self.scope == QuotaScope.AZ:
+            label_values['az'] = self.az
         return label_values
 
     @property
@@ -81,3 +85,22 @@ class RegionQuotaCheck(QuotaCheck):
         super().__init__(session)
 
         self.region = region
+
+class AvailabilityZoneQuotaCheck(QuotaCheck):
+    scope = QuotaScope.AZ
+    az: str = None
+
+    def __init__(self, session, az) -> None:
+        super().__init__(session)
+
+        self.az = az
+
+    @staticmethod
+    def get_availability_zones(session: boto3.Session) -> typing.List[str]:
+        azs = []
+        client = session.client('ec2')
+        filter = [
+            {'Name':'region-name', 'Values': [session.region_name]},
+            {'Name':'state', 'Values': ['available']}
+        ]
+        return [az['ZoneName'] for az in client.describe_availability_zones(Filters=filter)['AvailabilityZones']]

--- a/aws_quota/prometheus.py
+++ b/aws_quota/prometheus.py
@@ -7,7 +7,7 @@ import time
 import contextlib
 import typing
 
-from aws_quota.check.quota_check import InstanceQuotaCheck, RegionQuotaCheck, QuotaCheck
+from aws_quota.check.quota_check import InstanceQuotaCheck, RegionQuotaCheck, QuotaCheck, AvailabilityZoneQuotaCheck
 
 import boto3
 import prometheus_client as prom
@@ -104,6 +104,11 @@ class PrometheusExporter:
                             for rg in self.regions:
                                 self.session = boto3.Session(region_name=rg)
                                 checks.append(chk(self.session, rg))
+                        elif issubclass(chk, AvailabilityZoneQuotaCheck):
+                            for rg in self.regions:
+                                self.session = boto3.Session(region_name=rg)
+                                for az in chk.get_availability_zones(self.session):
+                                    checks.append(chk(self.session, az))
                         else:
                             checks.append(chk(self.session))
                     except Exception:


### PR DESCRIPTION
This PR corrects the `NatGatewayCountCheck` making it scoped to Availability Zone:
* add AvailabilityZoneQuotaCheck QuotaCheck class
* add AvailabilityZoneQuotaCheck support to check cli
* add AvailabilityZoneQuotaCheck support to prometheus-exporter
* make NatGatewayCountCheck AZ scoped
* rename `NatGatewayCountCheck` from `nat_count` to `ng_count` to follow other quotas (e.g. InternetGatewayCountCheck -> `ig_count`)

## Example output

### `check` command
```
$ aws-quota-checker check ig_count,ng_count --regions eu-central-1,us-east-1

AWS profile: cloud | AWS region: eu-central-1 | Active checks: ig_count,ng_count
Collecting checks  [####################################]  100%
VPC internet gateways per Region [1234567890/eu-central-1]: 0/20 ✓
VPC internet gateways per Region [1234567890/us-east-1]: 1/20 ✓
NAT gateways per Availability Zone [1234567890/eu-central-1/eu-central-1a]: 0/20 ✓
NAT gateways per Availability Zone [1234567890/eu-central-1/eu-central-1b]: 0/20 ✓
NAT gateways per Availability Zone [1234567890/eu-central-1/eu-central-1c]: 0/20 ✓
NAT gateways per Availability Zone [1234567890/us-east-1/us-east-1a]: 0/20 ✓
NAT gateways per Availability Zone [1234567890/us-east-1/us-east-1b]: 1/20 ✓
NAT gateways per Availability Zone [1234567890/us-east-1/us-east-1c]: 0/20 ✓
NAT gateways per Availability Zone [1234567890/us-east-1/us-east-1d]: 0/20 ✓
NAT gateways per Availability Zone [1234567890/us-east-1/us-east-1e]: 0/20 ✓
NAT gateways per Availability Zone [1234567890/us-east-1/us-east-1f]: 0/20 ✓
```


### `prometheus-exporter`
```
$ aws-quota-checker prometheus-exporter ig_count,ng_count --regions eu-central-1,us-east-1

AWS profile: cloud | AWS region: eu-central-1 | Active checks: ig_count,ng_count
24-Apr-23 17:12:08 [INFO] aws_quota.prometheus - starting /metrics endpoint on port 8080
24-Apr-23 17:12:08 [INFO] aws_quota.prometheus - collecting checks
24-Apr-23 17:12:12 [INFO] aws_quota.prometheus - collected 11 checks
24-Apr-23 17:12:12 [INFO] aws_quota.prometheus - refreshing limits
24-Apr-23 17:12:22 [INFO] aws_quota.prometheus - limits refreshed
24-Apr-23 17:12:22 [INFO] aws_quota.prometheus - refreshing current values
24-Apr-23 17:12:25 [INFO] aws_quota.prometheus - current values refreshed
```

```
$ curl localhost:8080
# HELP awsquota_info AWS quota checker info
# TYPE awsquota_info gauge
awsquota_info{account="1234567890",region="eu-central-1"} 1.0
# HELP awsquota_check_count Number of AWS Quota Checks
# TYPE awsquota_check_count gauge
awsquota_check_count 11.0
# HELP awsquota_collect_checks_duration_seconds Time to collect all quota checks
# TYPE awsquota_collect_checks_duration_seconds gauge
awsquota_collect_checks_duration_seconds{account="1234567890",region="eu-central-1"} 3.649510383605957
# HELP awsquota_ig_count_limit_duration_seconds Time to collect VPC internet gateways per Region Limit
# TYPE awsquota_ig_count_limit_duration_seconds gauge
awsquota_ig_count_limit_duration_seconds{account="1234567890",region="us-east-1"} 0.6539497375488281
# HELP awsquota_ig_count_limit VPC internet gateways per Region Limit
# TYPE awsquota_ig_count_limit gauge
awsquota_ig_count_limit{account="1234567890",quota="ig_count",region="eu-central-1"} 20.0
awsquota_ig_count_limit{account="1234567890",quota="ig_count",region="us-east-1"} 20.0
# HELP awsquota_ng_count_limit_duration_seconds Time to collect NAT gateways per Availability Zone Limit
# TYPE awsquota_ng_count_limit_duration_seconds gauge
awsquota_ng_count_limit_duration_seconds{account="1234567890",region="us-east-1"} 0.6401901245117188
# HELP awsquota_ng_count_limit NAT gateways per Availability Zone Limit
# TYPE awsquota_ng_count_limit gauge
awsquota_ng_count_limit{account="1234567890",az="eu-central-1a",quota="ng_count",region="eu-central-1"} 20.0
awsquota_ng_count_limit{account="1234567890",az="eu-central-1b",quota="ng_count",region="eu-central-1"} 20.0
awsquota_ng_count_limit{account="1234567890",az="eu-central-1c",quota="ng_count",region="eu-central-1"} 20.0
awsquota_ng_count_limit{account="1234567890",az="us-east-1a",quota="ng_count",region="us-east-1"} 20.0
awsquota_ng_count_limit{account="1234567890",az="us-east-1b",quota="ng_count",region="us-east-1"} 20.0
awsquota_ng_count_limit{account="1234567890",az="us-east-1c",quota="ng_count",region="us-east-1"} 20.0
awsquota_ng_count_limit{account="1234567890",az="us-east-1d",quota="ng_count",region="us-east-1"} 20.0
awsquota_ng_count_limit{account="1234567890",az="us-east-1e",quota="ng_count",region="us-east-1"} 20.0
awsquota_ng_count_limit{account="1234567890",az="us-east-1f",quota="ng_count",region="us-east-1"} 20.0
# HELP awsquota_check_limits_duration_seconds Time to check limits of all quotas
# TYPE awsquota_check_limits_duration_seconds gauge
awsquota_check_limits_duration_seconds{account="1234567890",region="us-east-1"} 9.497443437576294
# HELP awsquota_ig_count_duration_seconds Time to collect VPC internet gateways per Region
# TYPE awsquota_ig_count_duration_seconds gauge
awsquota_ig_count_duration_seconds{account="1234567890",region="us-east-1"} 0.6616511344909668
# HELP awsquota_ig_count VPC internet gateways per Region
# TYPE awsquota_ig_count gauge
awsquota_ig_count{account="1234567890",quota="ig_count",region="eu-central-1"} 0.0
awsquota_ig_count{account="1234567890",quota="ig_count",region="us-east-1"} 1.0
# HELP awsquota_ng_count_duration_seconds Time to collect NAT gateways per Availability Zone
# TYPE awsquota_ng_count_duration_seconds gauge
awsquota_ng_count_duration_seconds{account="1234567890",region="us-east-1"} 1.0013580322265625e-05
# HELP awsquota_ng_count NAT gateways per Availability Zone
# TYPE awsquota_ng_count gauge
awsquota_ng_count{account="1234567890",az="eu-central-1a",quota="ng_count",region="eu-central-1"} 0.0
awsquota_ng_count{account="1234567890",az="eu-central-1b",quota="ng_count",region="eu-central-1"} 0.0
awsquota_ng_count{account="1234567890",az="eu-central-1c",quota="ng_count",region="eu-central-1"} 0.0
awsquota_ng_count{account="1234567890",az="us-east-1a",quota="ng_count",region="us-east-1"} 0.0
awsquota_ng_count{account="1234567890",az="us-east-1b",quota="ng_count",region="us-east-1"} 1.0
awsquota_ng_count{account="1234567890",az="us-east-1c",quota="ng_count",region="us-east-1"} 0.0
awsquota_ng_count{account="1234567890",az="us-east-1d",quota="ng_count",region="us-east-1"} 0.0
awsquota_ng_count{account="1234567890",az="us-east-1e",quota="ng_count",region="us-east-1"} 0.0
awsquota_ng_count{account="1234567890",az="us-east-1f",quota="ng_count",region="us-east-1"} 0.0
# HELP awsquota_check_currents_duration_seconds Time to check limits of all quotas
# TYPE awsquota_check_currents_duration_seconds gauge
awsquota_check_currents_duration_seconds{account="1234567890",region="us-east-1"} 2.8815524578094482
```
